### PR TITLE
Fix websocket subscriptions to not double close.

### DIFF
--- a/graphql/handler/transport/websocket.go
+++ b/graphql/handler/transport/websocket.go
@@ -358,12 +358,8 @@ func (c *wsConnection) subscribe(start time.Time, msg *message) {
 
 			c.sendResponse(msg.id, response)
 		}
-		c.complete(msg.id)
 
-		c.mu.Lock()
-		delete(c.active, msg.id)
-		c.mu.Unlock()
-		cancel()
+		// complete and context cancel comes from the defer
 	}()
 }
 

--- a/graphql/handler/transport/websocket_test.go
+++ b/graphql/handler/transport/websocket_test.go
@@ -137,6 +137,19 @@ func TestWebsocket(t *testing.T) {
 		msg = readOp(c)
 		require.Equal(t, completeMsg, msg.Type)
 		require.Equal(t, "test_1", msg.ID)
+
+		// At this point we should be done and should not receive another message.
+		c.SetReadDeadline(time.Now().UTC().Add(1 * time.Millisecond))
+
+		err := c.ReadJSON(&msg)
+		if err == nil {
+			// This should not send a second close message for the same id.
+			require.NotEqual(t, completeMsg, msg.Type)
+			require.NotEqual(t, "test_1", msg.ID)
+		} else {
+			assert.Contains(t, err.Error(), "timeout")
+		}
+
 	})
 }
 


### PR DESCRIPTION
We were closing at the end of the loop and also in the defer.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
