### PR TITLE
Fix support for resolvers on input types in single file mode…

### DIFF
--- a/codegen/testserver/followschema/resolver.go
+++ b/codegen/testserver/followschema/resolver.go
@@ -537,6 +537,11 @@ func (r *wrappedSliceResolver) Get(ctx context.Context, obj WrappedSlice, idx in
 	panic("not implemented")
 }
 
+// OverrideFirstField is the resolver for the overrideFirstField field.
+func (r *fieldsOrderInputResolver) OverrideFirstField(ctx context.Context, obj *FieldsOrderInput, data *string) error {
+	panic("not implemented")
+}
+
 // BackedByInterface returns BackedByInterfaceResolver implementation.
 func (r *Resolver) BackedByInterface() BackedByInterfaceResolver {
 	return &backedByInterfaceResolver{r}
@@ -589,6 +594,9 @@ func (r *Resolver) WrappedMap() WrappedMapResolver { return &wrappedMapResolver{
 // WrappedSlice returns WrappedSliceResolver implementation.
 func (r *Resolver) WrappedSlice() WrappedSliceResolver { return &wrappedSliceResolver{r} }
 
+// FieldsOrderInput returns FieldsOrderInputResolver implementation.
+func (r *Resolver) FieldsOrderInput() FieldsOrderInputResolver { return &fieldsOrderInputResolver{r} }
+
 type backedByInterfaceResolver struct{ *Resolver }
 type deferModelResolver struct{ *Resolver }
 type errorsResolver struct{ *Resolver }
@@ -605,3 +613,4 @@ type subscriptionResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }
 type wrappedMapResolver struct{ *Resolver }
 type wrappedSliceResolver struct{ *Resolver }
+type fieldsOrderInputResolver struct{ *Resolver }

--- a/codegen/testserver/singlefile/resolver.go
+++ b/codegen/testserver/singlefile/resolver.go
@@ -537,6 +537,11 @@ func (r *wrappedSliceResolver) Get(ctx context.Context, obj WrappedSlice, idx in
 	panic("not implemented")
 }
 
+// OverrideFirstField is the resolver for the overrideFirstField field.
+func (r *fieldsOrderInputResolver) OverrideFirstField(ctx context.Context, obj *FieldsOrderInput, data *string) error {
+	panic("not implemented")
+}
+
 // BackedByInterface returns BackedByInterfaceResolver implementation.
 func (r *Resolver) BackedByInterface() BackedByInterfaceResolver {
 	return &backedByInterfaceResolver{r}
@@ -589,6 +594,9 @@ func (r *Resolver) WrappedMap() WrappedMapResolver { return &wrappedMapResolver{
 // WrappedSlice returns WrappedSliceResolver implementation.
 func (r *Resolver) WrappedSlice() WrappedSliceResolver { return &wrappedSliceResolver{r} }
 
+// FieldsOrderInput returns FieldsOrderInputResolver implementation.
+func (r *Resolver) FieldsOrderInput() FieldsOrderInputResolver { return &fieldsOrderInputResolver{r} }
+
 type backedByInterfaceResolver struct{ *Resolver }
 type deferModelResolver struct{ *Resolver }
 type errorsResolver struct{ *Resolver }
@@ -605,3 +613,4 @@ type subscriptionResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }
 type wrappedMapResolver struct{ *Resolver }
 type wrappedSliceResolver struct{ *Resolver }
+type fieldsOrderInputResolver struct{ *Resolver }

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -66,7 +66,7 @@ func (m *Plugin) generateSingleFile(data *codegen.Data) error {
 		return err
 	}
 
-	for _, o := range data.Objects {
+	for _, o := range append(data.Objects, data.Inputs...) {
 		if o.HasResolvers() {
 			caser := cases.Title(language.English, cases.NoLower)
 			rewriter.MarkStructCopied(templates.LcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type))

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -26,6 +26,13 @@ func TestLayoutSingleFile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, p.GenerateCode(data))
+
+	b, err := os.ReadFile("testdata/singlefile/out/resolver.go")
+	require.NoError(t, err)
+	source := string(b)
+	require.Contains(t, source, "func (r *CustomResolverType) Query() QueryResolver { return &queryCustomResolverType{r} }")
+	require.Contains(t, source, "func (r *testInputCustomResolverType) InputName(ctx context.Context, obj *TestInput, data string) error {")
+
 	assertNoErrors(t, "github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out")
 }
 

--- a/plugin/resolvergen/testdata/filetemplate/gqlgen.yml
+++ b/plugin/resolvergen/testdata/filetemplate/gqlgen.yml
@@ -14,5 +14,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/filetemplate/out/model.go
+++ b/plugin/resolvergen/testdata/filetemplate/out/model.go
@@ -3,6 +3,7 @@ package customresolver
 import "context"
 
 type Resolver struct{}
+type TestInput struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)
@@ -10,4 +11,7 @@ type QueryResolver interface {
 
 type ResolverResolver interface {
 	Name(ctx context.Context, obj *Resolver) (string, error)
+}
+type TestInputResolver interface {
+	InputName(ctx context.Context, obj *TestInput, data string) error
 }

--- a/plugin/resolvergen/testdata/followschema/gqlgen.yml
+++ b/plugin/resolvergen/testdata/followschema/gqlgen.yml
@@ -13,5 +13,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/followschema/out/model.go
+++ b/plugin/resolvergen/testdata/followschema/out/model.go
@@ -3,6 +3,7 @@ package customresolver
 import "context"
 
 type Resolver struct{}
+type TestInput struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)
@@ -10,4 +11,7 @@ type QueryResolver interface {
 
 type ResolverResolver interface {
 	Name(ctx context.Context, obj *Resolver) (string, error)
+}
+type TestInputResolver interface {
+	InputName(ctx context.Context, obj *TestInput, data string) error
 }

--- a/plugin/resolvergen/testdata/omit_template_comment/gqlgen.yml
+++ b/plugin/resolvergen/testdata/omit_template_comment/gqlgen.yml
@@ -14,5 +14,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/omit_template_comment/out/schema.resolvers.go
+++ b/plugin/resolvergen/testdata/omit_template_comment/out/schema.resolvers.go
@@ -20,11 +20,20 @@ func (r *resolverCustomResolverType) Name(ctx context.Context, obj *customresolv
 	panic(fmt.Errorf("not implemented: Name - name"))
 }
 
+func (r *testInputCustomResolverType) InputName(ctx context.Context, obj *customresolver.TestInput, data string) error {
+	panic(fmt.Errorf("not implemented: InputName - input_name"))
+}
+
 func (r *CustomResolverType) Query() customresolver.QueryResolver { return &queryCustomResolverType{r} }
 
 func (r *CustomResolverType) Resolver() customresolver.ResolverResolver {
 	return &resolverCustomResolverType{r}
 }
 
+func (r *CustomResolverType) TestInput() customresolver.TestInputResolver {
+	return &testInputCustomResolverType{r}
+}
+
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
+type testInputCustomResolverType struct{ *CustomResolverType }

--- a/plugin/resolvergen/testdata/resolver_implementor/gqlgen.yml
+++ b/plugin/resolvergen/testdata/resolver_implementor/gqlgen.yml
@@ -13,5 +13,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/resolver_implementor/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/resolver_implementor/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/resolver_implementor/out/model.go
+++ b/plugin/resolvergen/testdata/resolver_implementor/out/model.go
@@ -3,6 +3,7 @@ package customresolver
 import "context"
 
 type Resolver struct{}
+type TestInput struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)
@@ -10,4 +11,7 @@ type QueryResolver interface {
 
 type ResolverResolver interface {
 	Name(ctx context.Context, obj *Resolver) (string, error)
+}
+type TestInputResolver interface {
+	InputName(ctx context.Context, obj *TestInput, data string) error
 }

--- a/plugin/resolvergen/testdata/resolver_implementor/out/schema.resolvers.go
+++ b/plugin/resolvergen/testdata/resolver_implementor/out/schema.resolvers.go
@@ -18,11 +18,20 @@ func (r *resolverCustomResolverType) Name(ctx context.Context, obj *Resolver) (s
 	panic("implementor implemented me")
 }
 
+// InputName is the resolver for the input_name field.
+func (r *testInputCustomResolverType) InputName(ctx context.Context, obj *TestInput, data string) error {
+	panic("implementor implemented me")
+}
+
 // Query returns QueryResolver implementation.
 func (r *CustomResolverType) Query() QueryResolver { return &queryCustomResolverType{r} }
 
 // Resolver returns ResolverResolver implementation.
 func (r *CustomResolverType) Resolver() ResolverResolver { return &resolverCustomResolverType{r} }
 
+// TestInput returns TestInputResolver implementation.
+func (r *CustomResolverType) TestInput() TestInputResolver { return &testInputCustomResolverType{r} }
+
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
+type testInputCustomResolverType struct{ *CustomResolverType }

--- a/plugin/resolvergen/testdata/resolvertemplate/gqlgen.yml
+++ b/plugin/resolvergen/testdata/resolvertemplate/gqlgen.yml
@@ -15,5 +15,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/resolvertemplate/out/schema.resolvers.go
+++ b/plugin/resolvergen/testdata/resolvertemplate/out/schema.resolvers.go
@@ -23,6 +23,12 @@ func (r *resolverCustomResolverType) Name(ctx context.Context, obj *customresolv
 	panic(fmt.Errorf("custom Resolver not implemented: Name - name"))
 }
 
+// InputName is the resolver for the input_name field.
+func (r *testInputCustomResolverType) InputName(ctx context.Context, obj *customresolver.TestInput, data string) error {
+	// Custom Resolver implementation
+	panic(fmt.Errorf("custom Resolver not implemented: InputName - inputName"))
+}
+
 // Query returns customresolver.QueryResolver implementation.
 func (r *CustomResolverType) Query() customresolver.QueryResolver { return &queryCustomResolverType{r} }
 
@@ -31,5 +37,11 @@ func (r *CustomResolverType) Resolver() customresolver.ResolverResolver {
 	return &resolverCustomResolverType{r}
 }
 
+// TestInput returns customresolver.TestInputResolver implementation.
+func (r *CustomResolverType) TestInput() customresolver.TestInputResolver {
+	return &testInputCustomResolverType{r}
+}
+
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
+type testInputCustomResolverType struct{ *CustomResolverType }

--- a/plugin/resolvergen/testdata/schema.graphql
+++ b/plugin/resolvergen/testdata/schema.graphql
@@ -5,3 +5,7 @@ type Query {
 type Resolver {
     name: String!
 }
+
+input TestInput {
+    input_name: String!
+}

--- a/plugin/resolvergen/testdata/singlefile/gqlgen.yml
+++ b/plugin/resolvergen/testdata/singlefile/gqlgen.yml
@@ -13,5 +13,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/singlefile/out/model.go
+++ b/plugin/resolvergen/testdata/singlefile/out/model.go
@@ -3,6 +3,7 @@ package customresolver
 import "context"
 
 type Resolver struct{}
+type TestInput struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)
@@ -10,4 +11,8 @@ type QueryResolver interface {
 
 type ResolverResolver interface {
 	Name(ctx context.Context, obj *Resolver) (string, error)
+}
+
+type TestInputResolver interface {
+	InputName(ctx context.Context, obj *TestInput, data string) error
 }

--- a/plugin/resolvergen/testdata/singlefile/out/resolver.go
+++ b/plugin/resolvergen/testdata/singlefile/out/resolver.go
@@ -18,11 +18,20 @@ func (r *resolverCustomResolverType) Name(ctx context.Context, obj *Resolver) (s
 	panic("not implemented")
 }
 
+// InputName is the resolver for the input_name field.
+func (r *testInputCustomResolverType) InputName(ctx context.Context, obj *TestInput, data string) error {
+	panic("not implemented")
+}
+
 // Query returns QueryResolver implementation.
 func (r *CustomResolverType) Query() QueryResolver { return &queryCustomResolverType{r} }
 
 // Resolver returns ResolverResolver implementation.
 func (r *CustomResolverType) Resolver() ResolverResolver { return &resolverCustomResolverType{r} }
 
+// TestInput returns TestInputResolver implementation.
+func (r *CustomResolverType) TestInput() TestInputResolver { return &testInputCustomResolverType{r} }
+
 type queryCustomResolverType struct{ *CustomResolverType }
 type resolverCustomResolverType struct{ *CustomResolverType }
+type testInputCustomResolverType struct{ *CustomResolverType }

--- a/plugin/resolvergen/testdata/singlefile_preserve/gqlgen.yml
+++ b/plugin/resolvergen/testdata/singlefile_preserve/gqlgen.yml
@@ -13,5 +13,7 @@ resolver:
 models:
   Resolver:
     model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile_preserve/out.Resolver
+  TestInput:
+    model: github.com/99designs/gqlgen/plugin/resolvergen/testdata/singlefile_preserve/out.TestInput
 
 omit_gqlgen_version_in_file_notice: true

--- a/plugin/resolvergen/testdata/singlefile_preserve/out/model.go
+++ b/plugin/resolvergen/testdata/singlefile_preserve/out/model.go
@@ -3,6 +3,7 @@ package customresolver
 import "context"
 
 type Resolver struct{}
+type TestInput struct{}
 
 type QueryResolver interface {
 	Resolver(ctx context.Context) (*Resolver, error)
@@ -10,4 +11,7 @@ type QueryResolver interface {
 
 type ResolverResolver interface {
 	Name(ctx context.Context, obj *Resolver) (string, error)
+}
+type TestInputResolver interface {
+	InputName(ctx context.Context, obj *TestInput, data string) error
 }


### PR DESCRIPTION
… in the resolver plugin

gqlgen's resolver plugin does not handle input types with resolvers correctly when generating 
only a single output file. This change fixes that. 
It was doing it correctly in the follow-schema mode.

I have:
 - [x] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [x] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
