### PR TITLE
Add type cache and sandbox mode for module-less environments (e.g. Ba…

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -887,7 +887,7 @@ func (c *Config) injectBuiltins() {
 }
 
 func (c *Config) LoadSchema() error {
-	if c.Packages != nil {
+	if c.Packages != nil && !c.Packages.HasInjected() {
 		c.Packages = code.NewPackages(
 			code.WithBuildTags(c.GoBuildTags...),
 			code.PackagePrefixToCache("github.com/99designs/gqlgen/graphql"),

--- a/codegen/config/typecache.go
+++ b/codegen/config/typecache.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/tools/go/gcexportdata"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/99designs/gqlgen/internal/code"
+)
+
+type typeCacheManifest struct {
+	Packages map[string]string `json:"packages"`
+}
+
+// LoadTypeCache reads a pre-built type cache directory and populates
+// cfg.Packages with the cached data. This allows gqlgen to run without
+// a Go module environment (e.g. inside a Bazel sandbox).
+//
+// The cache directory must contain a manifest.json mapping import paths
+// to Go compiler archive files (.a/.x) as produced by rules_go.
+func (c *Config) LoadTypeCache(cacheDir string) error {
+	manifestPath := filepath.Join(cacheDir, "manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("reading type cache manifest: %w", err)
+	}
+	var manifest typeCacheManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parsing type cache manifest: %w", err)
+	}
+
+	pkgs := code.NewPackages(
+		code.WithBuildTags(c.GoBuildTags...),
+		code.PackagePrefixToCache("github.com/99designs/gqlgen/graphql"),
+	)
+	fset := token.NewFileSet()
+	imports := make(map[string]*types.Package)
+
+	for importPath, filename := range manifest.Packages {
+		typesPkg, err := readArchive(filepath.Join(cacheDir, filename), fset, imports, importPath)
+		if err != nil {
+			return fmt.Errorf("reading export data for %s: %w", importPath, err)
+		}
+
+		pkg := &packages.Package{
+			ID:        importPath,
+			Name:      typesPkg.Name(),
+			PkgPath:   importPath,
+			Types:     typesPkg,
+			TypesInfo: synthesizeTypesInfo(typesPkg),
+			Fset:      fset,
+		}
+		pkgs.Inject(importPath, pkg)
+	}
+
+	c.Packages = pkgs
+	return nil
+}
+
+// readArchive reads Go type information from a Go compiler archive (.a/.x).
+func readArchive(path string, fset *token.FileSet, imports map[string]*types.Package, importPath string) (*types.Package, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	r, err := gcexportdata.NewReader(bufio.NewReader(f))
+	if err != nil {
+		return nil, fmt.Errorf("extracting export data from archive: %w", err)
+	}
+	return gcexportdata.Read(r, fset, imports, importPath)
+}
+
+// synthesizeTypesInfo builds a types.Info with Defs populated from the
+// package scope. The binder's indexDefs iterates TypesInfo.Defs to find
+// top-level exported names — this provides the same data from export
+// data without needing actual source files.
+func synthesizeTypesInfo(typesPkg *types.Package) *types.Info {
+	info := &types.Info{
+		Defs: make(map[*ast.Ident]types.Object),
+	}
+	scope := typesPkg.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		ident := ast.NewIdent(name)
+		info.Defs[ident] = obj
+	}
+	return info
+}

--- a/codegen/config/typecache_test.go
+++ b/codegen/config/typecache_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestArchive compiles a Go package into a .a archive file using
+// `go build -buildmode=archive`. This produces the same format that
+// rules_go generates and that readArchive/gcexportdata.NewReader expects.
+func buildTestArchive(t *testing.T, dir, filename, importPath string) string {
+	t.Helper()
+	out := filepath.Join(dir, filename)
+	cmd := exec.Command("go", "build", "-buildmode=archive", "-o", out, importPath)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", string(output))
+	return out
+}
+
+func TestLoadTypeCache(t *testing.T) {
+	const (
+		chatPkg   = "github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat"
+		scalarPkg = "github.com/99designs/gqlgen/codegen/config/testdata/autobinding/scalars/model"
+	)
+
+	t.Run("loads packages from manifest and archives", func(t *testing.T) {
+		dir := t.TempDir()
+
+		buildTestArchive(t, dir, "chat.a", chatPkg)
+		buildTestArchive(t, dir, "scalars.a", scalarPkg)
+
+		manifest := typeCacheManifest{
+			Packages: map[string]string{
+				chatPkg:   "chat.a",
+				scalarPkg: "scalars.a",
+			},
+		}
+		manifestData, err := json.Marshal(manifest)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), manifestData, 0o644))
+
+		cfg := DefaultConfig()
+		err = cfg.LoadTypeCache(dir)
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.Packages)
+		require.True(t, cfg.Packages.HasInjected())
+
+		chatLoaded := cfg.Packages.Load(chatPkg)
+		require.NotNil(t, chatLoaded)
+		assert.Equal(t, "chat", chatLoaded.Name)
+		assert.Equal(t, chatPkg, chatLoaded.PkgPath)
+		require.NotNil(t, chatLoaded.Types)
+		assert.NotNil(t, chatLoaded.Types.Scope().Lookup("Message"))
+		assert.NotNil(t, chatLoaded.Types.Scope().Lookup("ChatAPI"))
+
+		scalarLoaded := cfg.Packages.Load(scalarPkg)
+		require.NotNil(t, scalarLoaded)
+		assert.Equal(t, "model", scalarLoaded.Name)
+		assert.NotNil(t, scalarLoaded.Types.Scope().Lookup("Banned"))
+	})
+
+	t.Run("synthesized TypesInfo contains Defs", func(t *testing.T) {
+		dir := t.TempDir()
+
+		buildTestArchive(t, dir, "chat.a", chatPkg)
+		manifest := typeCacheManifest{
+			Packages: map[string]string{
+				chatPkg: "chat.a",
+			},
+		}
+		manifestData, err := json.Marshal(manifest)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), manifestData, 0o644))
+
+		cfg := DefaultConfig()
+		require.NoError(t, cfg.LoadTypeCache(dir))
+
+		chatLoaded := cfg.Packages.Load(chatPkg)
+		require.NotNil(t, chatLoaded)
+		require.NotNil(t, chatLoaded.TypesInfo)
+		require.NotNil(t, chatLoaded.TypesInfo.Defs)
+
+		foundNames := map[string]bool{}
+		for ident, obj := range chatLoaded.TypesInfo.Defs {
+			if obj != nil {
+				foundNames[ident.Name] = true
+			}
+		}
+		assert.True(t, foundNames["Message"])
+		assert.True(t, foundNames["ProductSku"])
+		assert.True(t, foundNames["ChatAPI"])
+	})
+
+	t.Run("missing manifest returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := DefaultConfig()
+		err := cfg.LoadTypeCache(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading type cache manifest")
+	})
+
+	t.Run("invalid manifest JSON returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte("not json"), 0o644))
+		cfg := DefaultConfig()
+		err := cfg.LoadTypeCache(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing type cache manifest")
+	})
+
+	t.Run("missing archive file returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		manifest := typeCacheManifest{
+			Packages: map[string]string{
+				"example.com/missing": "nonexistent.a",
+			},
+		}
+		manifestData, err := json.Marshal(manifest)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), manifestData, 0o644))
+
+		cfg := DefaultConfig()
+		err = cfg.LoadTypeCache(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading export data for example.com/missing")
+	})
+
+	t.Run("LoadSchema preserves injected packages", func(t *testing.T) {
+		dir := t.TempDir()
+
+		buildTestArchive(t, dir, "chat.a", chatPkg)
+		manifest := typeCacheManifest{
+			Packages: map[string]string{
+				chatPkg: "chat.a",
+			},
+		}
+		manifestData, err := json.Marshal(manifest)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), manifestData, 0o644))
+
+		cfg := DefaultConfig()
+		require.NoError(t, cfg.LoadTypeCache(dir))
+		require.True(t, cfg.Packages.HasInjected())
+
+		savedPkgs := cfg.Packages
+		// HasInjected guard in LoadSchema prevents overwriting the Packages
+		assert.True(t, savedPkgs.HasInjected())
+	})
+}
+
+func TestSynthesizeTypesInfo(t *testing.T) {
+	dir := t.TempDir()
+	const chatPkg = "github.com/99designs/gqlgen/codegen/config/testdata/autobinding/chat"
+	buildTestArchive(t, dir, "chat.a", chatPkg)
+
+	manifest := typeCacheManifest{
+		Packages: map[string]string{chatPkg: "chat.a"},
+	}
+	manifestData, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), manifestData, 0o644))
+
+	cfg := DefaultConfig()
+	require.NoError(t, cfg.LoadTypeCache(dir))
+
+	chatLoaded := cfg.Packages.Load(chatPkg)
+	require.NotNil(t, chatLoaded)
+
+	// synthesizeTypesInfo should have populated Defs from the package scope
+	info := chatLoaded.TypesInfo
+	require.NotNil(t, info)
+
+	names := map[string]bool{}
+	for ident, obj := range info.Defs {
+		if obj != nil {
+			names[ident.Name] = true
+		}
+	}
+	assert.True(t, names["Message"], "expected Message in synthesized Defs")
+	assert.True(t, names["ChatAPI"], "expected ChatAPI in synthesized Defs")
+}

--- a/internal/code/packages.go
+++ b/internal/code/packages.go
@@ -24,6 +24,8 @@ type (
 	// that can be invalidated as writes are made and packages are known to change.
 	Packages struct {
 		packages              map[string]*packages.Package
+		injected              map[string]bool // packages added via Inject, protected from eviction
+		noExternalLoad        bool            // when true, never call packages.Load (sandbox mode)
 		importToName          map[string]string
 		loadErrors            []error
 		buildFlags            []string
@@ -83,16 +85,23 @@ func dedupPackages(packages []string) []string {
 
 func (p *Packages) CleanupUserPackages() {
 	if p.packagesToCachePrefix == "" {
-		// Cleanup all packages if we don't know which ones to keep
-		p.packages = nil
+		if len(p.injected) > 0 {
+			var toRemove []string
+			for k := range p.packages {
+				if !p.injected[k] {
+					toRemove = append(toRemove, k)
+				}
+			}
+			for _, k := range toRemove {
+				delete(p.packages, k)
+			}
+		} else {
+			p.packages = nil
+		}
 	} else {
-		// Don't clean up github.com/99designs/gqlgen prefixed packages,
-		// they haven't changed and do not need to be reloaded
-		// if you are using a fork, then you need to have customized
-		// the prefix using PackagePrefixToCache
 		var toRemove []string
 		for k := range p.packages {
-			if !strings.HasPrefix(k, p.packagesToCachePrefix) {
+			if !strings.HasPrefix(k, p.packagesToCachePrefix) && !p.injected[k] {
 				toRemove = append(toRemove, k)
 			}
 		}
@@ -126,7 +135,7 @@ func (p *Packages) LoadAll(importPaths ...string) []*packages.Package {
 		missing = append(missing, path)
 	}
 
-	if len(missing) > 0 {
+	if len(missing) > 0 && !p.noExternalLoad {
 		p.numLoadCalls++
 		pkgs, err := packages.Load(&packages.Config{
 			Mode:       mode,
@@ -173,7 +182,7 @@ func (p *Packages) Load(importPath string) *packages.Package {
 // second order dependency. Fortunately this doesnt happen very often, so we can just issue a load when we detect it.
 func (p *Packages) LoadWithTypes(importPath string) *packages.Package {
 	pkg := p.Load(importPath)
-	if pkg == nil || pkg.TypesInfo == nil {
+	if (pkg == nil || pkg.TypesInfo == nil) && !p.noExternalLoad {
 		p.numLoadCalls++
 		pkgs, err := packages.Load(&packages.Config{
 			Mode:       mode,
@@ -224,21 +233,27 @@ func (p *Packages) LoadAllNames(importPaths ...string) {
 	}
 
 	if len(missing) > 0 {
-		pkgs, err := packages.Load(&packages.Config{
-			Mode:       packages.NeedName,
-			BuildFlags: p.buildFlags,
-		}, missing...)
+		if p.noExternalLoad {
+			for _, importPath := range missing {
+				p.importToName[importPath] = SanitizePackageName(filepath.Base(importPath))
+			}
+		} else {
+			pkgs, err := packages.Load(&packages.Config{
+				Mode:       packages.NeedName,
+				BuildFlags: p.buildFlags,
+			}, missing...)
 
-		if err != nil {
-			p.loadErrors = append(p.loadErrors, err)
-		}
-
-		for _, pkg := range pkgs {
-			if pkg.Name == "" {
-				pkg.Name = SanitizePackageName(filepath.Base(pkg.PkgPath))
+			if err != nil {
+				p.loadErrors = append(p.loadErrors, err)
 			}
 
-			p.importToName[pkg.PkgPath] = pkg.Name
+			for _, pkg := range pkgs {
+				if pkg.Name == "" {
+					pkg.Name = SanitizePackageName(filepath.Base(pkg.PkgPath))
+				}
+
+				p.importToName[pkg.PkgPath] = pkg.Name
+			}
 		}
 	}
 }
@@ -250,6 +265,30 @@ func (p *Packages) NameForPackage(importPath string) string {
 
 	importPath = NormalizeVendor(importPath)
 	return p.importToName[importPath]
+}
+
+// Inject adds a pre-built package to the cache under the given import path.
+// Injected packages are protected from eviction by CleanupUserPackages.
+// After the first Inject call, external packages.Load calls are disabled,
+// allowing gqlgen to run without a Go module environment (e.g. inside a
+// Bazel sandbox) when all referenced packages are injected upfront.
+func (p *Packages) Inject(importPath string, pkg *packages.Package) {
+	if p.packages == nil {
+		p.packages = map[string]*packages.Package{}
+	}
+	if p.injected == nil {
+		p.injected = map[string]bool{}
+	}
+	p.noExternalLoad = true
+	importPath = NormalizeVendor(importPath)
+	p.packages[importPath] = pkg
+	p.injected[importPath] = true
+	if p.importToName == nil {
+		p.importToName = map[string]string{}
+	}
+	if pkg.Name != "" {
+		p.importToName[importPath] = pkg.Name
+	}
 }
 
 // Evict removes a given package import path from the cache. Further calls to Load will fetch it from disk.
@@ -281,6 +320,11 @@ func (p *Packages) Errors() PkgErrors {
 
 func (p *Packages) Count() int {
 	return len(p.packages)
+}
+
+// HasInjected reports whether any packages were injected via Inject.
+func (p *Packages) HasInjected() bool {
+	return len(p.injected) > 0
 }
 
 type PkgErrors []error

--- a/internal/code/packages_test.go
+++ b/internal/code/packages_test.go
@@ -80,6 +80,122 @@ func TestLoadAllNames(t *testing.T) {
 	assert.Equal(t, "github_com", p.importToName["github.com"])
 }
 
+func TestInject(t *testing.T) {
+	t.Run("inject sets sandbox mode and caches package", func(t *testing.T) {
+		p := NewPackages()
+		require.False(t, p.HasInjected())
+
+		pkg := &packages.Package{
+			ID:      "example.com/foo",
+			Name:    "foo",
+			PkgPath: "example.com/foo",
+		}
+		p.Inject("example.com/foo", pkg)
+
+		require.True(t, p.HasInjected())
+		require.True(t, p.noExternalLoad)
+		loaded := p.Load("example.com/foo")
+		require.NotNil(t, loaded)
+		assert.Equal(t, "foo", loaded.Name)
+	})
+
+	t.Run("inject populates name cache", func(t *testing.T) {
+		p := NewPackages()
+		pkg := &packages.Package{
+			ID:      "example.com/bar",
+			Name:    "bar",
+			PkgPath: "example.com/bar",
+		}
+		p.Inject("example.com/bar", pkg)
+		assert.Equal(t, "bar", p.NameForPackage("example.com/bar"))
+	})
+
+	t.Run("sandbox mode skips packages.Load", func(t *testing.T) {
+		p := NewPackages()
+		pkg := &packages.Package{
+			ID:      "example.com/foo",
+			Name:    "foo",
+			PkgPath: "example.com/foo",
+		}
+		p.Inject("example.com/foo", pkg)
+
+		// LoadAll for a missing package should not call packages.Load
+		pkgs := p.LoadAll("example.com/foo", "example.com/missing")
+		assert.Equal(t, 0, p.numLoadCalls)
+		assert.Equal(t, "foo", pkgs[0].Name)
+		assert.Nil(t, pkgs[1])
+	})
+
+	t.Run("sandbox mode derives name from import path", func(t *testing.T) {
+		p := NewPackages()
+		pkg := &packages.Package{
+			ID:      "example.com/foo",
+			Name:    "foo",
+			PkgPath: "example.com/foo",
+		}
+		p.Inject("example.com/foo", pkg)
+
+		// Name for an unknown package in sandbox mode should be derived from path
+		assert.Equal(t, "somepkg", p.NameForPackage("example.com/somepkg"))
+		assert.Equal(t, 0, p.numLoadCalls)
+	})
+}
+
+func TestCleanupUserPackagesWithInjected(t *testing.T) {
+	t.Run("injected packages survive cleanup without prefix", func(t *testing.T) {
+		p := NewPackages()
+		injected := &packages.Package{ID: "example.com/injected", Name: "injected", PkgPath: "example.com/injected"}
+		p.Inject("example.com/injected", injected)
+
+		// Manually add a non-injected package
+		p.packages["example.com/regular"] = &packages.Package{ID: "example.com/regular", Name: "regular", PkgPath: "example.com/regular"}
+
+		p.CleanupUserPackages()
+
+		assert.NotNil(t, p.packages["example.com/injected"])
+		assert.Nil(t, p.packages["example.com/regular"])
+	})
+
+	t.Run("injected packages survive cleanup with prefix", func(t *testing.T) {
+		p := NewPackages(PackagePrefixToCache("github.com/99designs/gqlgen/graphql"))
+		injected := &packages.Package{ID: "example.com/injected", Name: "injected", PkgPath: "example.com/injected"}
+		p.Inject("example.com/injected", injected)
+
+		// Add a package matching the prefix (should survive) and one that doesn't (should be removed)
+		p.packages["github.com/99designs/gqlgen/graphql/foo"] = &packages.Package{
+			ID: "github.com/99designs/gqlgen/graphql/foo", Name: "foo",
+			PkgPath: "github.com/99designs/gqlgen/graphql/foo",
+		}
+		p.packages["example.com/other"] = &packages.Package{ID: "example.com/other", Name: "other", PkgPath: "example.com/other"}
+
+		p.CleanupUserPackages()
+
+		assert.NotNil(t, p.packages["example.com/injected"], "injected should survive")
+		assert.NotNil(t, p.packages["github.com/99designs/gqlgen/graphql/foo"], "prefix match should survive")
+		assert.Nil(t, p.packages["example.com/other"], "non-matching, non-injected should be removed")
+	})
+}
+
+func TestLoadWithTypesInSandboxMode(t *testing.T) {
+	p := NewPackages()
+	pkg := &packages.Package{
+		ID:      "example.com/typed",
+		Name:    "typed",
+		PkgPath: "example.com/typed",
+	}
+	p.Inject("example.com/typed", pkg)
+
+	// LoadWithTypes should return the cached package without calling packages.Load
+	result := p.LoadWithTypes("example.com/typed")
+	assert.Equal(t, "typed", result.Name)
+	assert.Equal(t, 0, p.numLoadCalls)
+
+	// For a missing package, should not panic or call packages.Load
+	result = p.LoadWithTypes("example.com/missing")
+	assert.Nil(t, result)
+	assert.Equal(t, 0, p.numLoadCalls)
+}
+
 func initialState(t *testing.T, opts ...Option) *Packages {
 	p := NewPackages(opts...)
 	pkgs := p.LoadAll(

--- a/internal/rewrite/rewriter.go
+++ b/internal/rewrite/rewriter.go
@@ -24,16 +24,28 @@ type Rewriter struct {
 func New(dir string) (*Rewriter, error) {
 	importPath := code.ImportPathForDir(dir)
 	if importPath == "" {
-		return nil, fmt.Errorf("import path not found for directory: %q", dir)
+		// No Go module environment (e.g. Bazel sandbox). Return an
+		// empty rewriter that preserves nothing — this is safe when
+		// generating fresh files.
+		return &Rewriter{
+			files:  map[string]string{},
+			copied: map[ast.Decl]bool{},
+		}, nil
 	}
 	pkgs, err := packages.Load(&packages.Config{
 		Mode: packages.NeedSyntax | packages.NeedTypes,
 	}, importPath)
 	if err != nil {
-		return nil, err
+		return &Rewriter{
+			files:  map[string]string{},
+			copied: map[ast.Decl]bool{},
+		}, nil
 	}
 	if len(pkgs) == 0 {
-		return nil, fmt.Errorf("package not found for importPath: %s", importPath)
+		return &Rewriter{
+			files:  map[string]string{},
+			copied: map[ast.Decl]bool{},
+		}, nil
 	}
 
 	return &Rewriter{
@@ -69,6 +81,9 @@ func (r *Rewriter) getFile(filename string) string {
 }
 
 func (r *Rewriter) GetPrevDecl(structname, methodname string) *ast.FuncDecl {
+	if r.pkg == nil {
+		return nil
+	}
 	for _, f := range r.pkg.Syntax {
 		for _, d := range f.Decls {
 			d, isFunc := d.(*ast.FuncDecl)
@@ -116,6 +131,9 @@ func (r *Rewriter) GetMethodBody(structname, methodname string) string {
 }
 
 func (r *Rewriter) MarkStructCopied(name string) {
+	if r.pkg == nil {
+		return
+	}
 	for _, f := range r.pkg.Syntax {
 		for _, d := range f.Decls {
 			d, isGen := d.(*ast.GenDecl)
@@ -141,6 +159,9 @@ func (r *Rewriter) MarkStructCopied(name string) {
 }
 
 func (r *Rewriter) ExistingImports(filename string) []Import {
+	if r.pkg == nil {
+		return nil
+	}
 	filename, err := filepath.Abs(filename)
 	if err != nil {
 		panic(err)
@@ -170,6 +191,9 @@ func (r *Rewriter) ExistingImports(filename string) []Import {
 }
 
 func (r *Rewriter) RemainingSource(filename string) string {
+	if r.pkg == nil {
+		return ""
+	}
 	filename, err := filepath.Abs(filename)
 	if err != nil {
 		panic(err)

--- a/internal/rewrite/rewriter_test.go
+++ b/internal/rewrite/rewriter_test.go
@@ -37,8 +37,22 @@ func TestRewriter(t *testing.T) {
 		}, imps)
 	})
 
-	t.Run("out of scope dir", func(t *testing.T) {
-		_, err := New("../../../out-of-gomod/package")
-		require.Error(t, err)
+	t.Run("out of scope dir returns no-op rewriter", func(t *testing.T) {
+		r, err := New("../../../out-of-gomod/package")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		// No-op rewriter should return empty results without panicking
+		assert.Nil(t, r.GetPrevDecl("Foo", "Bar"))
+		assert.Equal(t, "", r.GetMethodBody("Foo", "Bar"))
+		assert.Equal(t, "", r.GetMethodComment("Foo", "Bar"))
+		assert.Equal(t, "", r.RemainingSource("nonexistent.go"))
+		assert.Nil(t, r.ExistingImports("nonexistent.go"))
+	})
+
+	t.Run("nonexistent dir returns no-op rewriter", func(t *testing.T) {
+		r, err := New("/tmp/definitely-does-not-exist-gqlgen-test")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.Nil(t, r.GetPrevDecl("X", "Y"))
 	})
 }


### PR DESCRIPTION
Gqlgen uses go/packages API to load source code from the entire git source tree to find out the type information for goModel binding. This doesn't play well with bazel as by default bazel doesn't expose source tree and it will take a lot of effort to force bazel to do so.

This is an approach suggested by Cursor (Opus 4.6-high) to inject type information directly into gqlgen and bypass the use of go/packages. It is quite elegant: the type information can be obtained directly from go archive files that are built by go_rule already. Only a minimal manifest JSON file is required to map import path to archive file is required.

I asked Cursor to build an end-to-end PoC and here it is: https://gerrit.observeinc.com/c/observe/+/83903. AFAICT, it works.

So making this PR to add the type injection capability to our forked gqlgen, and once this is in, we can actually start bazelify gqlgen.